### PR TITLE
[DCA-34] setup github OIDC

### DIFF
--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -38,7 +38,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
-          role-to-assume: arn:aws:iam::631692904429:role/meta-cdk-role
+          role-to-assume: arn:aws:iam::631692904429:role/sagebase-github-oidc-sage-ProviderRoledatacuratori-1KD3QGJEFWP7M
           role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
           role-duration-seconds: 1200
 


### PR DESCRIPTION
We setup an GH OIDC role in PR https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/697/ now we use the role to allow GH resources to deploy to AWS

depends on https://github.com/Sage-Bionetworks-IT/organizations-infra/pull/697