### PR TITLE
DCA-47: make SSL Policy more strict

### DIFF
--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -45,10 +45,6 @@ jobs:
           role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
           role-duration-seconds: 1200
 
-      - name: Log in to registry
-        # This is where you will update the personal access token to GITHUB_TOKEN
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
-
         # https://github.com/marketplace/actions/aws-cdk-github-actions
       - name: cdk synth
         uses: youyo/aws-cdk-github-actions@v2

--- a/cdk/docker_fargate/docker_fargate_stack.py
+++ b/cdk/docker_fargate/docker_fargate_stack.py
@@ -123,6 +123,7 @@ class DockerFargateStack(Stack):
             public_load_balancer=True,  # Default is False
             # TLS:
             protocol=elbv2.ApplicationProtocol.HTTPS,
+            ssl_policy=elbv2.SslPolicy.FORWARD_SECRECY_TLS12_RES, # Strong forward secrecy ciphers and TLS1.2 only.
             domain_name=get_host_name(), # The domain name for the service, e.g. “api.example.com.”
             domain_zone=zone) #  The Route53 hosted zone for the domain, e.g. “example.com.”
 


### PR DESCRIPTION
In support of DCA-47, this will help make DCA ready for future penetration tests by making the load balancer's SSL Policy more strict.