### PR TITLE
[DCA-49] standardize secret names

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,10 @@ Tests are available in the tests folder. Execute the following to run tests:
 ```
 python -m pytest tests/ -s -v
 ```
+
+## Secrets
+
+We use the [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html)
+to store secrets for this project.  An AWS practice is to create secrets with a unique ID.
+Our convention is `<cfn stack id>/<environment id>/<secret name>`.  An example is
+`MyTestStack/dev/MySecret`

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ python -m pytest tests/ -s -v
 ## Secrets
 
 We use the [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html)
-to store secrets for this project.  An AWS practice is to create secrets with a unique ID.
-Our convention is `<cfn stack id>/<environment id>/<secret name>`.  An example is
-`MyTestStack/dev/MySecret`
+to store secrets for this project.  An AWS best practice is to create secrets
+with a unique ID to prevent conflicts when multiple instances of this project
+is deployed to the same AWS account.  Our naming convention is
+`<cfn stack id>/<environment id>/<secret name>`.  An example is `MyTestStack/dev/MySecret`

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -31,8 +31,8 @@ ENV_NAME = "ENV"
 def create_id(env: dict) -> str:
     return env.get(STACK_NAME_PREFIX_CONTEXT) + ID_SUFFIX
 
-def create_secret(scope: Construct, name: str) -> str:
-    isecret = sm.Secret.from_secret_name_v2(scope, name, name)
+def create_secret(scope: Construct, id: str, name: str) -> str:
+    isecret = sm.Secret.from_secret_name_v2(scope, id, name)
     return ecs.Secret.from_secrets_manager(isecret)
     # see also: https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_ecs/Secret.html
     # see also: ecs.Secret.from_ssm_parameter(ssm.IParameter(parameter_name=name))
@@ -55,9 +55,6 @@ def get_cluster_name(env: dict) -> str:
 def get_service_name(env: dict) -> str:
     return env.get(STACK_NAME_PREFIX_CONTEXT) + SERVICE_SUFFIX
 
-def get_secret_name(env: dict) -> str:
-    return env.get(STACK_NAME_PREFIX_CONTEXT)
-
 def get_docker_image_name(env: dict):
     return env.get(IMAGE_PATH_AND_TAG_CONTEXT)
 
@@ -74,7 +71,7 @@ class DockerFargateStack(Stack):
         cluster = ecs.Cluster(self, get_cluster_name(env), vpc=vpc, container_insights=True)
 
         secrets = {
-            SECRETS_MANAGER_ENV_NAME: create_secret(self, get_secret_name(env))
+            SECRETS_MANAGER_ENV_NAME: create_secret(self, f'{stack_id}/{env}/ecs', "task_vars")
         }
 
         env_vars = {}


### PR DESCRIPTION
Use a standard naming convention for secrets.  This will prevent name collisions if we decide to deploy multiple stack environments in the same AWS account.

The naming convention used is `<cfn stack id>/<environment id>/<secret name>`. An example would be `MyTestApp/dev/mysecret`

