### PR TITLE
[DCA-49] Fix the secret ID

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,12 +7,12 @@ from docker_fargate.docker_fargate_stack import DockerFargateStack
 
 app = cdk.App()
 try:
-  app_config = helpers.get_app_config(app)
+  context, app_config = helpers.get_app_config(app)
 except Exception as err:
   raise SystemExit(err)
 
-vpc_stack = VpcStack(app, app_config)
-docker_fargate_stack = DockerFargateStack(app, app_config, vpc=vpc_stack.vpc)
+vpc_stack = VpcStack(app, context, app_config)
+docker_fargate_stack = DockerFargateStack(app, context, app_config, vpc=vpc_stack.vpc)
 docker_fargate_stack.add_dependency(vpc_stack)
 
 app.synth()

--- a/common/vpc_stack.py
+++ b/common/vpc_stack.py
@@ -12,7 +12,7 @@ VPC_CIDR_CONTEXT= "VPC_CIDR"
 
 class VpcStack(Stack):
 
-    def __init__(self, scope: Construct, env: dict, **kwargs) -> None:
+    def __init__(self, scope: Construct, context: str, env: dict, **kwargs) -> None:
         super().__init__(scope, STACK_ID, **kwargs)
         self.vpc = ec2.Vpc(self,
                            VPC_NAME,

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -31,7 +31,7 @@ ENV_NAME = "ENV"
 def create_id(env: dict) -> str:
     return env.get(STACK_NAME_PREFIX_CONTEXT) + ID_SUFFIX
 
-def create_secret(scope: Construct, id: str, name: str) -> str:
+def get_secret(scope: Construct, id: str, name: str) -> str:
     isecret = sm.Secret.from_secret_name_v2(scope, id, name)
     return ecs.Secret.from_secrets_manager(isecret)
     # see also: https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_ecs/Secret.html
@@ -70,8 +70,9 @@ class DockerFargateStack(Stack):
 
         cluster = ecs.Cluster(self, get_cluster_name(env), vpc=vpc, container_insights=True)
 
+        secret_name = f'{stack_id}/{context}/ecs'
         secrets = {
-            SECRETS_MANAGER_ENV_NAME: create_secret(self, f'{stack_id}/{context}/ecs', "task_vars")
+            SECRETS_MANAGER_ENV_NAME: get_secret(self, secret_name, secret_name)
         }
 
         env_vars = {}

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -64,14 +64,14 @@ def get_port(env: dict) -> int:
 
 class DockerFargateStack(Stack):
 
-    def __init__(self, scope: Construct, env: dict, vpc: ec2.Vpc, **kwargs) -> None:
+    def __init__(self, scope: Construct, context: str, env: dict, vpc: ec2.Vpc, **kwargs) -> None:
         stack_id = create_id(env)
         super().__init__(scope, stack_id, **kwargs)
 
         cluster = ecs.Cluster(self, get_cluster_name(env), vpc=vpc, container_insights=True)
 
         secrets = {
-            SECRETS_MANAGER_ENV_NAME: create_secret(self, f'{stack_id}/{env}/ecs', "task_vars")
+            SECRETS_MANAGER_ENV_NAME: create_secret(self, f'{stack_id}/{context}/ecs', "task_vars")
         }
 
         env_vars = {}

--- a/helpers.py
+++ b/helpers.py
@@ -10,4 +10,4 @@ def get_app_config(app: aws_cdk.App) -> dict:
       + ', '.join(config.CONTEXT_ENVS))
 
   app_config = app.node.try_get_context(context)
-  return app_config
+  return context, app_config

--- a/tests/unit/test_vpc_stack.py
+++ b/tests/unit/test_vpc_stack.py
@@ -8,7 +8,7 @@ def test_vpc_created():
     app = core.App()
     app_config = {config.COST_CENTER_CONTEXT: "test"}
 
-    stack = VpcStack(app, app_config)
+    stack = VpcStack(app, "dev", app_config)
     template = assertions.Template.from_stack(stack)
 
     template.has_resource_properties("AWS::EC2::VPC", {


### PR DESCRIPTION
The secret ID was incorrectly set to contain the env dictionary which cause the deployment to fail.  The fix is to change it to reference the context name which is just a string.

