### PR TITLE
Remove pip install in deployment pipeline

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -47,9 +47,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install dependencies
-        run: pip install -r requirements.txt -r requirements-dev.txt
-
         # Authenticate to AWS using GitHub OIDC
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v1
@@ -78,9 +75,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      - name: Install dependencies
-        run: pip install -r requirements.txt
 
         # Authenticate to AWS using GitHub OIDC
       - name: Assume AWS Role


### PR DESCRIPTION
The CDK GH action provides all the dependencies for the CDK app
therefore we don't need to pip install the dependencies.
