### PR TITLE
Upversion to v0.3.11-beta which uses a shiny server with simple_sched…

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -31,7 +31,7 @@
       "aws-cn"
     ],
     "dev": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.10-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.11-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "3838",
       "TAGS": {
@@ -42,7 +42,7 @@
       "VPC_CIDR": "10.255.70.0/24"
     },
     "prod": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.10-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.11-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "3838",
       "COST_CENTER": "NO PROGRAM / 000000",


### PR DESCRIPTION
…uler = 1.

PR Checklist:
[ ] Describe and explain your intentions for this change
This uses a shiny server configured with simple_scheduler = 1 to only allow one connection per instance. Running this locally didn't allow any connections. See what happens on AWS.
[ ] Setup pre-commit and run the validators (info in README.md)
