### PR TITLE
DCA-130: add two additional dev stacks

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -63,6 +63,20 @@ jobs:
           cdk_args: '--require-approval never --context env=dev --progress events --debug'
           actions_comment: false
 
+      - name: cdk deploy to org-sagebase-dnt-dev NO-STICKY (631692904429)
+        uses: youyo/aws-cdk-github-actions@v2
+        with:
+          cdk_subcommand: 'deploy'
+          cdk_args: '--require-approval never --context env=dev-no-sticky --progress events --debug'
+          actions_comment: false
+
+      - name: cdk deploy to org-sagebase-dnt-dev STICKY (631692904429)
+        uses: youyo/aws-cdk-github-actions@v2
+        with:
+          cdk_subcommand: 'deploy'
+          cdk_args: '--require-approval never --context env=dev-sticky --progress events --debug'
+          actions_comment: false
+
   cdk-deploy-prod:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/prod' }}

--- a/cdk.json
+++ b/cdk.json
@@ -39,7 +39,35 @@
       },
       "STACK_NAME_PREFIX": "dca",
       "ACM_CERT_ARN": "arn:aws:acm:us-east-1:631692904429:certificate/8644a975-2c1d-49ca-bc73-786745db0bc8",
-      "VPC_CIDR": "10.255.70.0/24"
+      "VPC_CIDR": "10.255.70.0/24",
+      "STICKY":"FALSE",
+      "DESIRED_TASK_COUNT":"1"
+    },
+    "dev-no-sticky": {
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.13-beta",
+      "AWS_DEFAULT_REGION": "us-east-1",
+      "PORT": "3838",
+      "TAGS": {
+        "CostCenter": "NO PROGRAM / 000000"
+      },
+      "STACK_NAME_PREFIX": "dca-no-sticky",
+      "ACM_CERT_ARN": "arn:aws:acm:us-east-1:631692904429:certificate/8644a975-2c1d-49ca-bc73-786745db0bc8",
+      "VPC_CIDR": "10.255.72.0/24",
+      "STICKY":"FALSE",
+      "DESIRED_TASK_COUNT":"2"
+    },
+    "dev-sticky": {
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.13-beta",
+      "AWS_DEFAULT_REGION": "us-east-1",
+      "PORT": "3838",
+      "TAGS": {
+        "CostCenter": "NO PROGRAM / 000000"
+      },
+      "STACK_NAME_PREFIX": "dca-sticky",
+      "ACM_CERT_ARN": "arn:aws:acm:us-east-1:631692904429:certificate/8644a975-2c1d-49ca-bc73-786745db0bc8",
+      "VPC_CIDR": "10.255.73.0/24",
+      "STICKY":"TRUE",
+      "DESIRED_TASK_COUNT":"2"
     },
     "prod": {
       "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.13-beta",

--- a/cdk.json
+++ b/cdk.json
@@ -76,7 +76,9 @@
       "COST_CENTER": "NO PROGRAM / 000000",
       "STACK_NAME_PREFIX": "dca",
       "ACM_CERT_ARN": "arn:aws:acm:us-east-1:878654265857:certificate/a3b7c804-c1fc-4e58-bbc6-541ef2d65816",
-      "VPC_CIDR": "10.255.71.0/24"
+      "VPC_CIDR": "10.255.71.0/24",
+      "STICKY":"FALSE",
+      "DESIRED_TASK_COUNT":"1"
     }
   }
 }

--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
 
-CONTEXT_ENVS = ["dev", "staging", "prod"]
+CONTEXT_ENVS = ["dev", "dev-no-sticky", "dev-sticky", "prod"]
 TAGS_CONTEXT = "TAGS"
 STACK_NAME_PREFIX_CONTEXT = "STACK_NAME_PREFIX"

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -45,7 +45,7 @@ def get_port(env: dict) -> int:
 def get_desired_task_count(env: dict) -> int:
     return int(env.get(DESIRED_TASK_COUNT))
 
-def get_sticky(env: dict) -> boolean:
+def get_sticky(env: dict) -> bool:
     return env.get(STICKY).lower()=="true"
 
 

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -41,12 +41,12 @@ def get_docker_image_name(env: dict):
 
 def get_port(env: dict) -> int:
     return int(env.get(PORT_NUMBER_CONTEXT))
-    
+
 def get_desired_task_count(env: dict) -> int:
     return int(env.get(DESIRED_TASK_COUNT))
-    
+
 def get_sticky(env: dict) -> boolean:
-	return env.get(STICKY).lower()=="true"
+    return env.get(STICKY).lower()=="true"
 
 
 class DockerFargateStack(Stack):
@@ -108,7 +108,7 @@ class DockerFargateStack(Stack):
         # https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_elasticloadbalancingv2/ApplicationTargetGroup.html#aws_cdk.aws_elasticloadbalancingv2.ApplicationTargetGroup
         load_balanced_fargate_service.target_group.configure_health_check(interval=Duration.seconds(120), timeout=Duration.seconds(60))
         if get_sticky():
-        	load_balanced_fargate_service.target_group.enable_cookie_stickiness(Duration.days(1), cookie_name=None)
+            load_balanced_fargate_service.target_group.enable_cookie_stickiness(Duration.days(1), cookie_name=None)
 
         if False: # enable/disable autoscaling
             scalable_target = load_balanced_fargate_service.service.auto_scale_task_count(

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -107,7 +107,7 @@ class DockerFargateStack(Stack):
         # Overriding health check timeout helps with sluggishly responding app's (e.g. Shiny)
         # https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_elasticloadbalancingv2/ApplicationTargetGroup.html#aws_cdk.aws_elasticloadbalancingv2.ApplicationTargetGroup
         load_balanced_fargate_service.target_group.configure_health_check(interval=Duration.seconds(120), timeout=Duration.seconds(60))
-        if get_sticky():
+        if get_sticky(env):
             load_balanced_fargate_service.target_group.enable_cookie_stickiness(Duration.days(1), cookie_name=None)
 
         if False: # enable/disable autoscaling

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -16,6 +16,8 @@ from constructs import Construct
 ACM_CERT_ARN_CONTEXT = "ACM_CERT_ARN"
 IMAGE_PATH_AND_TAG_CONTEXT = "IMAGE_PATH_AND_TAG"
 PORT_NUMBER_CONTEXT = "PORT"
+STICKY = "STICKY"
+DESIRED_TASK_COUNT="DESIRED_TASK_COUNT"
 
 # The name of the environment variable that will hold the secrets
 SECRETS_MANAGER_ENV_NAME = "SECRETS_MANAGER_SECRETS"
@@ -39,6 +41,12 @@ def get_docker_image_name(env: dict):
 
 def get_port(env: dict) -> int:
     return int(env.get(PORT_NUMBER_CONTEXT))
+    
+def get_desired_task_count(env: dict) -> int:
+    return int(env.get(DESIRED_TASK_COUNT))
+    
+def get_sticky(env: dict) -> boolean:
+	return env.get(STICKY).lower()=="true"
 
 
 class DockerFargateStack(Stack):
@@ -85,7 +93,7 @@ class DockerFargateStack(Stack):
             f'{stack_prefix}-Service',
             cluster=cluster,            # Required
             cpu=512,                    # Default is 256
-            desired_count=1,            # Number of copies of the 'task' (i.e. the app') running behind the ALB
+            desired_count=get_desired_task_count(env), # Number of copies of the 'task' (i.e. the app') running behind the ALB
             circuit_breaker=ecs.DeploymentCircuitBreaker(rollback=True), # Enable rollback on deployment failure
             task_image_options=task_image_options,
             memory_limit_mib=2048,      # Default is 512
@@ -99,6 +107,8 @@ class DockerFargateStack(Stack):
         # Overriding health check timeout helps with sluggishly responding app's (e.g. Shiny)
         # https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_elasticloadbalancingv2/ApplicationTargetGroup.html#aws_cdk.aws_elasticloadbalancingv2.ApplicationTargetGroup
         load_balanced_fargate_service.target_group.configure_health_check(interval=Duration.seconds(120), timeout=Duration.seconds(60))
+        if get_sticky():
+        	load_balanced_fargate_service.target_group.enable_cookie_stickiness(Duration.days(1), cookie_name=None)
 
         if False: # enable/disable autoscaling
             scalable_target = load_balanced_fargate_service.service.auto_scale_task_count(


### PR DESCRIPTION
Two test session stickiness, the 'dev' branch is updated to add two new dev stacks (for a total of three stacks).
The first stack, "dca-no-sticky", is just like the current dev' deployment but with *two* ECS task instances behind the load balancer. This should reproduce the failure seen earlier.
The second stack, "dca-sticky", also has two task instances but has "stickiness" enabled in the ALB target group.  The question is whether the behavior of DCA differs from the previous stack.