### PR TITLE
DCA-130:  Adding stickiness to 'dev' and 'prod' contexts; 4 instances behind the ALB

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -40,8 +40,8 @@
       "STACK_NAME_PREFIX": "dca",
       "ACM_CERT_ARN": "arn:aws:acm:us-east-1:631692904429:certificate/8644a975-2c1d-49ca-bc73-786745db0bc8",
       "VPC_CIDR": "10.255.70.0/24",
-      "STICKY":"FALSE",
-      "DESIRED_TASK_COUNT":"1"
+      "STICKY":"TRUE",
+      "DESIRED_TASK_COUNT":"4"
     },
     "dev-no-sticky": {
       "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.5-beta",
@@ -77,8 +77,8 @@
       "STACK_NAME_PREFIX": "dca",
       "ACM_CERT_ARN": "arn:aws:acm:us-east-1:878654265857:certificate/a3b7c804-c1fc-4e58-bbc6-541ef2d65816",
       "VPC_CIDR": "10.255.71.0/24",
-      "STICKY":"FALSE",
-      "DESIRED_TASK_COUNT":"1"
+      "STICKY":"TRUE",
+      "DESIRED_TASK_COUNT":"4"
     }
   }
 }


### PR DESCRIPTION
Adding stickiness to 'dev' and 'prod' contexts; 4 instances behind the ALB