### PR TITLE
incremented all images to 0.3.20-beta

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -31,7 +31,7 @@
       "aws-cn"
     ],
     "dev": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.19-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.20-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "3838",
       "TAGS": {
@@ -44,7 +44,7 @@
       "DESIRED_TASK_COUNT":"1"
     },
     "dev-no-sticky": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.5-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.20-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "3838",
       "TAGS": {
@@ -57,7 +57,7 @@
       "DESIRED_TASK_COUNT":"3"
     },
     "dev-sticky": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.5-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.20-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "3838",
       "TAGS": {
@@ -70,7 +70,7 @@
       "DESIRED_TASK_COUNT":"3"
     },
     "prod": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.19-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.20-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "3838",
       "TAGS": {


### PR DESCRIPTION
@milen-sage :

Since we have [all the DCA deployment](https://github.com/Sage-Bionetworks/data_curator-infra/blob/dev/cdk.json) environments we’d need for an extended testing of the DCA (thread in the dca deployment channel), could you update all the environment with a minor  change in the DCA [dcc config file](https://github.com/Sage-Bionetworks/data_curator/blob/develop/dcc_config.csv):
set submit_table_manipulation to upsert in the DCA Demo DCC
That way we could do more extensive testing on the upsert option.

