### PR TITLE
V0.3.25 beta

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -31,7 +31,7 @@
       "aws-cn"
     ],
     "dev": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.11-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.13-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "3838",
       "TAGS": {
@@ -42,7 +42,7 @@
       "VPC_CIDR": "10.255.70.0/24"
     },
     "prod": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.11-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.13-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "3838",
       "COST_CENTER": "NO PROGRAM / 000000",

--- a/cdk.json
+++ b/cdk.json
@@ -31,7 +31,7 @@
       "aws-cn"
     ],
     "dev": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.18-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.19-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "3838",
       "TAGS": {
@@ -70,10 +70,12 @@
       "DESIRED_TASK_COUNT":"3"
     },
     "prod": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.13-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.19-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "3838",
-      "COST_CENTER": "NO PROGRAM / 000000",
+      "TAGS": {
+        "CostCenter": "NO PROGRAM / 000000"
+      },
       "STACK_NAME_PREFIX": "dca",
       "ACM_CERT_ARN": "arn:aws:acm:us-east-1:878654265857:certificate/a3b7c804-c1fc-4e58-bbc6-541ef2d65816",
       "VPC_CIDR": "10.255.71.0/24",

--- a/cdk.json
+++ b/cdk.json
@@ -31,7 +31,7 @@
       "aws-cn"
     ],
     "dev": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.24-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.25-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "3838",
       "TAGS": {
@@ -44,7 +44,7 @@
       "DESIRED_TASK_COUNT":"1"
     },
     "dev-no-sticky": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.24-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.25-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "3838",
       "TAGS": {
@@ -57,7 +57,7 @@
       "DESIRED_TASK_COUNT":"3"
     },
     "dev-sticky": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.24-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.25-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "3838",
       "TAGS": {
@@ -70,7 +70,7 @@
       "DESIRED_TASK_COUNT":"3"
     },
     "prod": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.24-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.25-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "3838",
       "TAGS": {

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -84,8 +84,8 @@ class DockerFargateStack(Stack):
             self,
             f'{stack_prefix}-Service',
             cluster=cluster,            # Required
-            cpu=256,                    # Default is 256
-            desired_count=3,            # Number of copies of the 'task' (i.e. the app') running behind the ALB
+            cpu=512,                    # Default is 256
+            desired_count=1,            # Number of copies of the 'task' (i.e. the app') running behind the ALB
             circuit_breaker=ecs.DeploymentCircuitBreaker(rollback=True), # Enable rollback on deployment failure
             task_image_options=task_image_options,
             memory_limit_mib=2048,      # Default is 512
@@ -100,7 +100,7 @@ class DockerFargateStack(Stack):
         # https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_elasticloadbalancingv2/ApplicationTargetGroup.html#aws_cdk.aws_elasticloadbalancingv2.ApplicationTargetGroup
         load_balanced_fargate_service.target_group.configure_health_check(interval=Duration.seconds(120), timeout=Duration.seconds(60))
 
-        if True: # enable/disable autoscaling
+        if False: # enable/disable autoscaling
             scalable_target = load_balanced_fargate_service.service.auto_scale_task_count(
                min_capacity=3, # Minimum capacity to scale to. Default: 1
                max_capacity=15 # Maximum capacity to scale to.


### PR DESCRIPTION
PR Checklist:
[ ] Describe and explain your intentions for this change
To get Synapse folders within a project, use Schematic's storage/projects/dataset endpoint instead of Synapse's entity/children endpoint. Though the latter is faster, it does not return the correct folders for nested fileview structures, such as AMP AD. It those cases, the new behavior will filter annotations for `contentType=dataset`
[ ] Setup pre-commit and run the validators (info in README.md)
