### PR TITLE
Prod sticky & cleanup (#84)

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -63,20 +63,6 @@ jobs:
           cdk_args: '--require-approval never --context env=dev --progress events --debug'
           actions_comment: false
 
-      - name: cdk deploy to org-sagebase-dnt-dev NO-STICKY (631692904429)
-        uses: youyo/aws-cdk-github-actions@v2
-        with:
-          cdk_subcommand: 'deploy'
-          cdk_args: '--require-approval never --context env=dev-no-sticky --progress events --debug'
-          actions_comment: false
-
-      - name: cdk deploy to org-sagebase-dnt-dev STICKY (631692904429)
-        uses: youyo/aws-cdk-github-actions@v2
-        with:
-          cdk_subcommand: 'deploy'
-          cdk_args: '--require-approval never --context env=dev-sticky --progress events --debug'
-          actions_comment: false
-
   cdk-deploy-prod:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/prod' }}

--- a/cdk.json
+++ b/cdk.json
@@ -43,34 +43,8 @@
       "STICKY":"TRUE",
       "DESIRED_TASK_COUNT":"2"
     },
-    "dev-no-sticky": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.29-beta",
-      "AWS_DEFAULT_REGION": "us-east-1",
-      "PORT": "3838",
-      "TAGS": {
-        "CostCenter": "NO PROGRAM / 000000"
-      },
-      "STACK_NAME_PREFIX": "dca-no-sticky",
-      "ACM_CERT_ARN": "arn:aws:acm:us-east-1:631692904429:certificate/8644a975-2c1d-49ca-bc73-786745db0bc8",
-      "VPC_CIDR": "10.255.72.0/24",
-      "STICKY":"FALSE",
-      "DESIRED_TASK_COUNT":"2"
-    },
-    "dev-sticky": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.29-beta",
-      "AWS_DEFAULT_REGION": "us-east-1",
-      "PORT": "3838",
-      "TAGS": {
-        "CostCenter": "NO PROGRAM / 000000"
-      },
-      "STACK_NAME_PREFIX": "dca-sticky",
-      "ACM_CERT_ARN": "arn:aws:acm:us-east-1:631692904429:certificate/8644a975-2c1d-49ca-bc73-786745db0bc8",
-      "VPC_CIDR": "10.255.73.0/24",
-      "STICKY":"TRUE",
-      "DESIRED_TASK_COUNT":"2"
-    },
     "prod": {
-      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.29-beta",
+      "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.3.30-beta",
       "AWS_DEFAULT_REGION": "us-east-1",
       "PORT": "3838",
       "TAGS": {
@@ -79,7 +53,7 @@
       "STACK_NAME_PREFIX": "dca",
       "ACM_CERT_ARN": "arn:aws:acm:us-east-1:878654265857:certificate/a3b7c804-c1fc-4e58-bbc6-541ef2d65816",
       "VPC_CIDR": "10.255.71.0/24",
-      "STICKY":"FALSE",
+      "STICKY":"TRUE",
       "DESIRED_TASK_COUNT":"2"
     }
   }

--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
 
-CONTEXT_ENVS = ["dev", "dev-no-sticky", "dev-sticky", "prod"]
+CONTEXT_ENVS = ["dev", "prod"]
 TAGS_CONTEXT = "TAGS"
 STACK_NAME_PREFIX_CONTEXT = "STACK_NAME_PREFIX"


### PR DESCRIPTION
- Update prod image to v0.3.30-beta to sync with dev.
- Make prod instance "sticky"
- Remove dev-sticky and dev-no-sticky testing instances

PR Checklist:
[ ] Describe and explain your intentions for this change
[ ] Setup pre-commit and run the validators (info in README.md)
