### PR TITLE
Set up a metric and scalable target for active connection count.

### DIFF
--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -134,6 +134,9 @@ class DockerFargateStack(Stack):
             active_connection_metric = cloudwatch.Metric(
                 namespace = "AWS/ApplicationELB",
                 metric_name="ActiveConnectionCount"
+                period="60",
+                statistic="AVERAGE",
+                unit="COUNT"
             )
 
             scalable_target.scale_on_metric("ScaleToActiveConnection",

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -4,6 +4,7 @@ from aws_cdk import (Stack,
     aws_ecs_patterns as ecs_patterns,
     aws_elasticloadbalancingv2 as elbv2,
     aws_route53 as r53,
+    aws_cloudwatch as cloudwatch,
     CfnOutput,
     Duration,
     Tags)

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -129,7 +129,6 @@ class DockerFargateStack(Stack):
 
             # Other metrics to drive scaling are discussed here:
             # https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_autoscaling/README.html
-            
             # Add more capacity when active connections increase
             active_connection_metric = cloudwatch.Metric(
                 namespace = "AWS/ApplicationELB",

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -133,7 +133,7 @@ class DockerFargateStack(Stack):
             # Add more capacity when active connections increase
             active_connection_metric = cloudwatch.Metric(
                 namespace = "AWS/ApplicationELB",
-                metric_name="ActiveConnectionCount"
+                metric_name="ActiveConnectionCount",
                 period="60",
                 statistic="AVERAGE",
                 unit="COUNT"

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -142,7 +142,11 @@ class DockerFargateStack(Stack):
 
             scalable_target.scale_on_metric("ScaleToActiveConnection",
                 metric=active_connection_metric,
-                scaling_steps=[autoscaling.ScalingInterval(lower=3, change=+1), autoscaling.ScalingInterval(lower=6, change=+2), autoscaling.ScalingInterval(lower=9, change=+3)
+                scaling_steps=[
+                    autoscaling.ScalingInterval(lower=0, change=-1),
+                    autoscaling.ScalingInterval(lower=3, change=+1),
+                    autoscaling.ScalingInterval(lower=6, change=+2),
+                    autoscaling.ScalingInterval(lower=9, change=+3)
                 ],
                 adjustment_type=autoscaling.AdjustmentType.CHANGE_IN_CAPACITY
             )

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -129,6 +129,19 @@ class DockerFargateStack(Stack):
 
             # Other metrics to drive scaling are discussed here:
             # https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_autoscaling/README.html
+            
+            # Add more capacity when active connections increase
+            active_connection_metric = cloudwatch.Metric(
+                namespace = "AWS/ApplicationELB",
+                metric_name="ActiveConnectionCount"
+            )
+
+            scalable_target.scale_on_metric("ScaleToActiveConnection",
+                metric=active_connection_metric,
+                scaling_steps=[autoscaling.ScalingInterval(lower=3, change=+1), autoscaling.ScalingInterval(lower=6, change=+2), autoscaling.ScalingInterval(lower=9, change=+3)
+                ],
+                adjustment_type=autoscaling.AdjustmentType.CHANGE_IN_CAPACITY
+            )
 
         # Tag all resources in this Stack's scope with context tags
         for key, value in env.get(config.TAGS_CONTEXT).items():

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -5,6 +5,7 @@ from aws_cdk import (Stack,
     aws_elasticloadbalancingv2 as elbv2,
     aws_route53 as r53,
     aws_cloudwatch as cloudwatch,
+    aws_applicationautoscaling as autoscaling,
     CfnOutput,
     Duration,
     Tags)

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -134,9 +134,9 @@ class DockerFargateStack(Stack):
             active_connection_metric = cloudwatch.Metric(
                 namespace = "AWS/ApplicationELB",
                 metric_name="ActiveConnectionCount",
-                period="60",
+                period=Duration.seconds(60),
                 statistic="AVERAGE",
-                unit="COUNT"
+                unit=cloudwatch.Unit("COUNT")
             )
 
             scalable_target.scale_on_metric("ScaleToActiveConnection",


### PR DESCRIPTION
PR Checklist:
[ ] Describe and explain your intentions for this change

Goal: To enable autoscaling based on active connections. The sum of active connections over a period of one minute will be used as a metric to scale. Autoscaling will increase the number of instances by one for each count threshold that's passed. Start with thresholds of 3, 6, 9 based on [observations from our current alarm](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarmsV2:alarm/dca-active-connection?).

[This was created following this doc](https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_autoscaling/README.html). The metric to scale off is `ActiveConnectionCount` under the `AWS/ApplicationELB` namespace. 

We want to replicate and scale off [this alarm](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarmsV2:alarm/dca-active-connection?) which takes the sum of active connections over a sampling period of one minute.

Questions for reviewers:
- Do you think this code will accomplish the goal above?

[ ] Setup pre-commit and run the validators (info in README.md)
