### PR TITLE
increase dev instance memory for 0.5 to 1gb

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -45,7 +45,7 @@
       "MIN_INSTANCE_COUNT":"1",
       "MAX_INSTANCE_COUNT":"2",
       "CPU_SIZE":"256",
-      "MEMORY_SIZE":"512"
+      "MEMORY_SIZE":"1024"
     },
     "staging": {
       "IMAGE_PATH_AND_TAG": "ghcr.io/sage-bionetworks/data_curator:0.5.0-beta",


### PR DESCRIPTION
PR Checklist:
[ ] Describe and explain your intentions for this change

- the dev instance is now crashing after selecting a DCC without any error messages. This must be due to decreasing the dev instance size to 0.25 vcpu and 0.5gb memory. To test if it's a memory or vcpu issue, increase the memory to 1gb but leave vcpu as.

[ ] Setup pre-commit and run the validators (info in README.md)
