### PR TITLE
Change sticky cookie duration from 1 day to 10 minutes.

### DIFF
--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -126,7 +126,7 @@ class DockerFargateStack(Stack):
         # https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_elasticloadbalancingv2/ApplicationTargetGroup.html#aws_cdk.aws_elasticloadbalancingv2.ApplicationTargetGroup
         load_balanced_fargate_service.target_group.configure_health_check(interval=Duration.seconds(120), timeout=Duration.seconds(60))
         if get_sticky(env):
-            load_balanced_fargate_service.target_group.enable_cookie_stickiness(Duration.minutes(10), cookie_name=None)
+            load_balanced_fargate_service.target_group.enable_cookie_stickiness(Duration.minutes(15), cookie_name=None)
 
         if True: # enable/disable autoscaling
             scalable_target = load_balanced_fargate_service.service.auto_scale_task_count(

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -126,7 +126,7 @@ class DockerFargateStack(Stack):
         # https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_elasticloadbalancingv2/ApplicationTargetGroup.html#aws_cdk.aws_elasticloadbalancingv2.ApplicationTargetGroup
         load_balanced_fargate_service.target_group.configure_health_check(interval=Duration.seconds(120), timeout=Duration.seconds(60))
         if get_sticky(env):
-            load_balanced_fargate_service.target_group.enable_cookie_stickiness(Duration.days(1), cookie_name=None)
+            load_balanced_fargate_service.target_group.enable_cookie_stickiness(Duration.minutes(10), cookie_name=None)
 
         if True: # enable/disable autoscaling
             scalable_target = load_balanced_fargate_service.service.auto_scale_task_count(


### PR DESCRIPTION
PR Checklist:
[ ] Describe and explain your intentions for this change

[AWS docs](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/sticky-sessions.html) state the load balancer uses a cookie to route user traffic to the same instance. The DCA configurations that are loaded during instance configurations cannot update until a new instance is created. The current value of 1 day causes issues because a user's sticky session can cause an instance to stay alive after configurations have changed, such as secrets or github.com/sage-Bionetworks/data_curator_config/. Decreasing this to 10 minutes will both allow users plenty of time to complete their DCA work and let the instances update in a timely manner.

This may also help the app handle multiple users. Now a user using the app periodically over a day, let's say, can be routed to newly created instances.

[ ] Setup pre-commit and run the validators (info in README.md)
